### PR TITLE
feat: added optional description to Icon Items

### DIFF
--- a/src/cmd/library/generate/tasks/item/item_source.rs
+++ b/src/cmd/library/generate/tasks/item/item_source.rs
@@ -306,7 +306,7 @@ mod test {
         .unwrap();
         assert!(content.contains("LX_6N8UPcPbT0G"));
         assert!(content.contains(
-            r"IconElement($id, 'IconElement', 'Package/Module/Family/BuiltInItem', $name, $tech)"
+            r"IconElement($id, 'IconElement', 'Package/Module/Family/BuiltInItem', $name, $tech, $desc)"
         ));
         assert!(content.contains(
             r"IconCardElement($id, 'IconCardElement', '<$ItemLg>', 'Family', $funcName, $content)"

--- a/src/cmd/library/generate/templates/item_snippet.rs
+++ b/src/cmd/library/generate/templates/item_snippet.rs
@@ -21,7 +21,7 @@ include('{{ data.item_urn }}')
 {%- block procedures %}
 ' renders the element
 {%- if data.element_shape == "Icon" %}
-{{ data.procedure_name }}('{{ data.variable_name }}', '{{ data.primary_label }}', '{{ data.technical_label | default(value="an optional tech label") }}')
+{{ data.procedure_name }}('{{ data.variable_name }}', '{{ data.primary_label }}', '{{ data.technical_label | default(value="an optional tech label"), '{{ data.description_label | default(value="an optional description") }}')
 {% elif data.element_shape == "IconCard" %}
 {{ data.procedure_name }}('{{ data.variable_name }}', '{{ data.primary_label }}', '{{ data.description_label | default(value="an optional description") }}')
 {% elif data.element_shape == "IconGroup" %}

--- a/src/cmd/library/generate/templates/item_snippet.rs
+++ b/src/cmd/library/generate/templates/item_snippet.rs
@@ -21,7 +21,7 @@ include('{{ data.item_urn }}')
 {%- block procedures %}
 ' renders the element
 {%- if data.element_shape == "Icon" %}
-{{ data.procedure_name }}('{{ data.variable_name }}', '{{ data.primary_label }}', '{{ data.technical_label | default(value="an optional tech label"), '{{ data.description_label | default(value="an optional description") }}')
+{{ data.procedure_name }}('{{ data.variable_name }}', '{{ data.primary_label }}', '{{ data.technical_label | default(value="an optional tech label") }}', '{{ data.description_label | default(value="an optional description") }}')
 {% elif data.element_shape == "IconCard" %}
 {{ data.procedure_name }}('{{ data.variable_name }}', '{{ data.primary_label }}', '{{ data.description_label | default(value="an optional description") }}')
 {% elif data.element_shape == "IconGroup" %}

--- a/src/cmd/library/generate/templates/item_source.rs
+++ b/src/cmd/library/generate/templates/item_source.rs
@@ -11,8 +11,8 @@ pub const TEMPLATE: &str = r##"{% block header -%}
 {%- block elements %}
 {%- for element in data.elements %}
 {%- if element.type == "Icon" %}
-!procedure {{ element.procedure_name }}($id, $name="", $tech="")
-  IconElement($id, '{{ element.stereotype_name }}', '{{ element.icon_urn }}', $name, $tech)
+!procedure {{ element.procedure_name }}($id, $name="", $tech="", $desc="")
+  IconElement($id, '{{ element.stereotype_name }}', '{{ element.icon_urn }}', $name, $tech, $desc)
 !endprocedure
 {%- elif element.type == "IconCard" %}
 !procedure {{ element.procedure_name }}($id, $funcName="", $content="")

--- a/src/cmd/library/generate/templates/library_bootstrap.rs
+++ b/src/cmd/library/generate/templates/library_bootstrap.rs
@@ -96,13 +96,16 @@ skinparam DefaultFontColor $FONT_COLOR
 
 ' IconElement
 {% block procedure_IconElement %}
-!procedure IconElement($id, $stereotype, $icon, $name="", $tech="")
+!procedure IconElement($id, $stereotype, $icon, $name="", $tech="", $desc="")
     !local $H="<img:" + getIcon($icon)+ ">"
     !if ($name != "")
         !$H=$H + "\n" + $name
     !endif
     !if ($tech != "")
         !$H=$H + "\n" + "<size:" + $FONT_SIZE_XS + "><color:" + $FONT_COLOR_LIGHT + ">[" + $tech + "]</color></size>"
+    !endif
+    !if ($desc != "")
+        !$H=$H + "\n\n" + $desc
     !endif
     card $id <<$stereotype>> as "$H"
 !endprocedure


### PR DESCRIPTION
After attempting to check how the elements were created in the libs repository found this way instead to update them all... however, I am not able to run the scripts as there is some error during the build

```log
 => [builder 6/6] RUN cargo build --release --features vendored-openssl
 => => # error: could not compile `cc`
 => => # Caused by:
 => => #   process didn't exit successfully: `rustc --crate-name cc --edition=2018 /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/cc-1.0.69/src/lib.rs --error-format=json --json=diagnostic-rendered-an
 => => # si,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debug-assertions=off -C metadata=4210e52f53f6b87b -C extra-filename=-4210e52f53f6b87b --out-dir /usr/sr
 => => # c/plantuml-generator/target/release/deps -L dependency=/usr/src/plantuml-generator/target/release/deps --cap-lints allow` (signal: 11, SIGSEGV: invalid memory reference)
 => => # warning: build failed, waiting for other jobs to finish...
```