### PR TITLE
fix(ci): pin valid github actions

### DIFF
--- a/.github/workflows/Continuous-Integration.yml
+++ b/.github/workflows/Continuous-Integration.yml
@@ -179,7 +179,7 @@ jobs:
       - name: "Process version of the tag"
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         id: version
-        uses: PaulHatch/semantic-version-action@v5
+        uses: ncipollo/semantic-version-action@v1
       - name: "Build and push tags"
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: docker/build-push-action@v5
@@ -224,7 +224,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Create the release"
-        uses: ncipollo/release-action@v1.14
+        uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
           artifacts: "artifacts/**/*.tar.gz,artifacts/**/*.deb"


### PR DESCRIPTION
Fix the CI workflow by replacing dead action references with valid releases:\n- ncipollo/semantic-version-action@v1\n- ncipollo/release-action@v1