### PR TITLE
fix(docker): copy benches into build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update -y && \
 WORKDIR /usr/src/plantuml-generator
 COPY Cargo.toml Cargo.lock /usr/src/plantuml-generator/
 COPY src /usr/src/plantuml-generator/src
+COPY benches /usr/src/plantuml-generator/benches
 RUN cargo build --release --features vendored-openssl
 
 FROM docker.io/ubuntu:22.04


### PR DESCRIPTION
The Docker image build was failing because Cargo validated Cargo.toml inside the builder image and could not find the declared benchmark source file. The Dockerfile only copied src/, so benches/ was missing from the build context.

This change copies benches/ into the builder stage so cargo build --release --features vendored-openssl can parse the manifest successfully.
