### PR TITLE
build(tera): migrate tera from 1.20.1 to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,28 +377,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono-tz"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
-]
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,12 +643,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-
-[[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
@@ -999,17 +971,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,15 +1065,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "hybrid-array"
@@ -1312,22 +1264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ignore"
-version = "0.4.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
-]
-
-[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,12 +1438,6 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lebe"
@@ -1858,15 +1788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,86 +1814,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
-dependencies = [
- "pest",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.7",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -2238,22 +2079,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -2270,31 +2100,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2349,7 +2160,7 @@ dependencies = [
  "paste",
  "profiling",
  "rand 0.9.5",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "simd_helpers",
  "thiserror",
  "v_frame",
@@ -2869,26 +2680,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slug"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "smallvec"
@@ -3002,24 +2797,13 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.20.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
+checksum = "511f07fd91a70e92efbe4793d111aaa9035f8474dd157aaa1e31e7c27f5051da"
 dependencies = [
- "chrono",
- "chrono-tz",
- "globwalk",
- "humansize",
- "lazy_static",
- "percent-encoding",
- "pest",
- "pest_derive",
- "rand 0.8.7",
- "regex",
+ "globset",
  "serde",
- "serde_json",
- "slug",
- "unicode-segmentation",
+ "walkdir",
 ]
 
 [[package]]
@@ -3232,22 +3016,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 serde_yaml_ok = { version = "0.9" }
 schemars = { version = "1" }
-tera = { version = "1" }
+tera = { version = "2", features = ["glob_fs"] }
 zip = { version = "8" }
 
 [dev-dependencies]

--- a/src/cmd/library/generate/generator.rs
+++ b/src/cmd/library/generate/generator.rs
@@ -423,21 +423,21 @@ mod tests {
         );
 
         // Phase 3 (Render Atomic): Individual documentation files exist
-        let c4model_readme = format!("{}/c4model/README.md", &dist_dir);
+        let c4model_readme = format!("{}/c4model/README.md", dist_dir);
         assert!(
             Path::new(&c4model_readme).exists(),
             "Atomic templates should be rendered in phase 3"
         );
 
         // Phase 4 (Render Composed): Composite files exist
-        let single_puml = format!("{}/c4model/single.puml", &dist_dir);
+        let single_puml = format!("{}/c4model/single.puml", dist_dir);
         assert!(
             Path::new(&single_puml).exists(),
             "Composed templates should be rendered in phase 4"
         );
 
         // Phase 5 (Render Sources): PlantUML diagrams rendered
-        let element_person_png = format!("{}/c4model/Element/Person.Local.png", &dist_dir);
+        let element_person_png = format!("{}/c4model/Element/Person.Local.png", dist_dir);
         assert!(
             Path::new(&element_person_png).exists(),
             "PlantUML diagrams should be rendered in phase 5"

--- a/src/cmd/library/generate/tasks/item/element_snippet.rs
+++ b/src/cmd/library/generate/tasks/item/element_snippet.rs
@@ -60,8 +60,10 @@ pub struct ElementSnippetTask {
     /// The label of the element.
     primary_label: String,
     /// The technical label of the element.
+    #[serde(skip_serializing_if = "Option::is_none")]
     technical_label: Option<String>,
     /// The description label of the element.
+    #[serde(skip_serializing_if = "Option::is_none")]
     description_label: Option<String>,
     /// The name of the Tera template
     template: String,
@@ -309,6 +311,7 @@ mod test {
                 }
                 assert!(content.contains(r##"include('PackageA/ModuleB/FamilyC/Item')"##));
                 assert!(content.contains(format!("{}(", generator.procedure_name).as_str()));
+                assert!(content.contains("an optional"));
             }
         }
     }

--- a/src/cmd/library/generate/templates/item_documentation.rs
+++ b/src/cmd/library/generate/templates/item_documentation.rs
@@ -21,7 +21,7 @@ include('{{ data.item_urn }}')
 {% endblock objects %}
 
 {% block sprites %}
-{% set icons = data.objects | filter(attribute="type", value="Icon") -%}
+{% set icons = [object for object in data.objects if object.type == "Icon"] -%}
 {% if icons | length > 0 -%}
 ## Sprites
 The item provides the following sriptes:
@@ -34,7 +34,7 @@ The item provides the following sriptes:
 {% endif -%}
 {% endblock sprites %}
 
-{% set elements = data.objects | filter(attribute="type", value="Element") -%}
+{% set elements = [object for object in data.objects if object.type == "Element"] -%}
 {% block elements %}
 {% if elements | length > 0 -%}
 {% for element in elements %}

--- a/src/cmd/library/generate/templates/library_bootstrap.rs
+++ b/src/cmd/library/generate/templates/library_bootstrap.rs
@@ -31,7 +31,7 @@ pub const TEMPLATE: &str = r##"{%- block header %}{% endblock header %}
 !global $FONT_SIZE_LG={{ data.font_size_lg }}
 !global $FONT_COLOR="{{ data.font_color }}"
 !global $FONT_COLOR_LIGHT="{{ data.font_color_light }}"
-{% endblock contants %}
+{% endblock constants %}
 
 ' Styles
 {% block styles %}

--- a/src/cmd/library/generate/templates/module_documentation.rs
+++ b/src/cmd/library/generate/templates/module_documentation.rs
@@ -5,7 +5,7 @@ pub const TEMPLATE: &str = r##"# {{ data.module_name }}
 {% set nbr_items = data.items_with_family | length + data.items_without_family | length -%}
 The module contains {{ nbr_items }} items.
 
-{% set families = data.items_with_family | map(attribute="family") | unique | sort -%}
+{% set families = [item.family for item in data.items_with_family] | unique | sort -%}
 {% for family in families -%}
 - [{{ family }}](#family-{{ family | lower }})
 {% endfor %}

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -1,65 +1,34 @@
-use std::collections::HashMap;
 use std::fs::read_to_string;
 use std::path::Path;
 
 use anyhow::Result;
-use tera::{Function, Tera, Value};
+use tera::{Kwargs, State, Tera, TeraResult, Value};
 
-struct ReadFileContentFunction {}
-
-impl Function for ReadFileContentFunction {
-    fn call(&self, args: &HashMap<String, Value>) -> tera::Result<Value> {
-        let path_as_value = match args.get("path") {
-            None => return Err(tera::Error::from("the argument `path` is missing")),
-            Some(p) => p,
-        };
-        let path_as_string = match path_as_value.as_str() {
-            None => {
-                return Err(tera::Error::from(
-                    "unable to convert the `path` to a string",
-                ));
-            }
-            Some(p) => p,
-        };
-        let path = Path::new(path_as_string);
-        let content = match read_to_string(path).map_err(tera::Error::from) {
-            Ok(c) => c,
-            Err(e) => {
-                log::error!("unable to read {}", path_as_string);
-                return Err(e);
-            }
-        };
-        Ok(Value::String(content))
-    }
-
-    fn is_safe(&self) -> bool {
-        false
-    }
+fn read_file_content(kwargs: Kwargs, _state: &State) -> TeraResult<Value> {
+    let path_as_string: String = kwargs.must_get("path")?;
+    let path = Path::new(&path_as_string);
+    let content = read_to_string(path).map_err(|e| {
+        log::error!("unable to read {}", path_as_string);
+        tera::Error::chain(format!("unable to read {}", path_as_string), e)
+    })?;
+    Ok(Value::from(content))
 }
 
 pub fn create_tera(
     templates: Vec<(&str, &str)>,
     additional_directory: Option<String>,
 ) -> Result<Tera> {
-    let mut primary = Tera::default();
+    let mut tera = Tera::default();
 
-    primary
-        .add_raw_templates(templates)
-        .map_err(|e| anyhow::Error::new(e).context("unable to create the primary Tera instance"))?;
-    primary.register_function("read_file_content", ReadFileContentFunction {});
+    tera.register_function("read_file_content", read_file_content);
+    tera.add_raw_templates(templates)
+        .map_err(|e| anyhow::Error::new(e).context("unable to create the Tera instance"))?;
 
-    let tera = match additional_directory {
-        None => primary,
-        Some(directory) => {
-            let secondary = Tera::parse(&directory).map_err(|e| {
-                anyhow::Error::new(e).context("unable to create the secondary Tera instance")
-            })?;
-            primary.extend(&secondary).map_err(|e| {
-                anyhow::Error::new(e).context("unable to extend the primary tera instance")
-            })?;
-            primary
-        }
-    };
+    if let Some(directory) = additional_directory {
+        tera.load_from_glob(&directory).map_err(|e| {
+            anyhow::Error::new(e).context("unable to load additional templates into Tera")
+        })?;
+    }
 
     Ok(tera)
 }

--- a/test/tera/package_bootstrap_bis.tera
+++ b/test/tera/package_bootstrap_bis.tera
@@ -4,7 +4,7 @@
 {%- endblock header %}
 {% block content -%}
 ' content
-{%- endblock footer -%}
+{%- endblock content -%}
 {% block footer -%}
 ' footer
 {%- endblock footer %}


### PR DESCRIPTION
## Summary
- Migrate the `tera` templating crate from 1.20.1 to 2.1.0 (major rewrite: `glob_fs` feature gate, removed `Tera::parse`/`.extend()`/`filter`/`map` filters, new plain-function `Function` API, stricter template-add-time validation, undefined-variable access now errors instead of rendering empty).
- Rewrote `src/tera.rs` around the new single-instance `add_raw_templates()` → `load_from_glob()` flow and plain-function `read_file_content`.
- Converted the two `filter`/`map` builtin usages in `item_documentation.rs` and `module_documentation.rs` to list comprehensions.
- Fixed two pre-existing mismatched `{% endblock %}` name typos that v1 silently tolerated but v2's stricter validation now rejects.
- **Fix**: `technical_label`/`description_label` (`Option<String>`) now skip serialization when `None`, restoring the `default()` filter fallback that tera 2.x broke for JSON `null` (it now only substitutes on `Undefined`, not `null`). Added a regression-guard assertion in the existing snippet-rendering test.

## Verification
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo build --all-features --all-targets`, `cargo test` (174 unit + 20 e2e) all pass.
- **Real-world audit**: built pre/post-migration Docker images and ran the actual `eip` (Enterprise Integration Patterns) package from `tmorin/plantuml-libs` through both, diffing the full generated distribution (569 files). Initial run surfaced the `default()`/null regression above (430 files differed); after the fix, 566/569 files are byte-identical, with the remaining 3 differing only by ~0.09% of pixels along anti-aliased edges in dot-laid-out example diagrams — confirmed unrelated to tera (identical source `.puml`, identical PNG text metadata) and consistent with pre-existing Graphviz/Java rendering non-determinism.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --all-features --all-targets`
- [x] `cargo test` (full suite)
- [x] Local Docker-based before/after audit against a real external PlantUML library package (`eip` from `tmorin/plantuml-libs`)
- [ ] CI (fmt/clippy/build/test across the full matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f6wTYR1TxkioKJcFKVWb4